### PR TITLE
feat(quiz): added display for correct / wrong answers on round leaderboard

### DIFF
--- a/functions/src/quiz/round-end.ts
+++ b/functions/src/quiz/round-end.ts
@@ -45,7 +45,7 @@ export const QuizRoundEnd = functions
         // Build leaderboard
         const leaderboard = players.docs.reduce((leaders, doc) => {
             const player = doc.data();
-            leaders[ player.user ] = { answers: Array(round.questionList.length).fill(null), score: 0 };
+            leaders[ player.user ] = { user: player.user, answers: Array(round.questionList.length).fill(null), score: 0 };
             return leaders;
         }, {});
 

--- a/functions/test/features/quiz/round-end.feature
+++ b/functions/test/features/quiz/round-end.feature
@@ -26,7 +26,7 @@ Feature:
         And the document contains:
             | answers | [ true, false, null, true ] |
             | score   | 2                           |
-            | user    | {{ game.players[1].uid }}  |
+            | user    | {{ game.players[1].uid }}   |
         Then there is a collection "quizzes" with document "{{ quiz.uid }}"
         And there is a sub-collection "rounds" with document "{{ quiz.rounds[1].uid }}"
         And there is a sub-collection "results" with document "{{ game.players[2].uid }}"

--- a/functions/test/features/quiz/round-end.feature
+++ b/functions/test/features/quiz/round-end.feature
@@ -24,11 +24,13 @@ Feature:
         And there is a sub-collection "rounds" with document "{{ quiz.rounds[1].uid }}"
         And there is a sub-collection "results" with document "{{ game.players[1].uid }}"
         And the document contains:
-            | score   | 2                           |
             | answers | [ true, false, null, true ] |
+            | score   | 2                           |
+            | user    | {{ game.players[1],uid }}  |
         Then there is a collection "quizzes" with document "{{ quiz.uid }}"
         And there is a sub-collection "rounds" with document "{{ quiz.rounds[1].uid }}"
         And there is a sub-collection "results" with document "{{ game.players[2].uid }}"
         And the document contains:
-            | score   | 0                          |
             | answers | [ null, null, null, null ] |
+            | score   | 0                          |
+            | user    | {{ game.players[2],uid }}  |

--- a/functions/test/features/quiz/round-end.feature
+++ b/functions/test/features/quiz/round-end.feature
@@ -26,11 +26,11 @@ Feature:
         And the document contains:
             | answers | [ true, false, null, true ] |
             | score   | 2                           |
-            | user    | {{ game.players[1],uid }}  |
+            | user    | {{ game.players[1].uid }}  |
         Then there is a collection "quizzes" with document "{{ quiz.uid }}"
         And there is a sub-collection "rounds" with document "{{ quiz.rounds[1].uid }}"
         And there is a sub-collection "results" with document "{{ game.players[2].uid }}"
         And the document contains:
             | answers | [ null, null, null, null ] |
             | score   | 0                          |
-            | user    | {{ game.players[2],uid }}  |
+            | user    | {{ game.players[2].uid }}  |

--- a/hosting/src/app/games/quiz/leaderboard/leaderboard.component.html
+++ b/hosting/src/app/games/quiz/leaderboard/leaderboard.component.html
@@ -8,8 +8,14 @@
     <li *ngFor="let leader of results">
         <game-avatar [user]="leader.user"></game-avatar>
         <div>
-            <h4>{{ leader.user.alias }}</h4>
-            <div>Score: {{ leader.score }}</div>
+            <h4>{{ leader.user.alias }} ( {{ leader.score }} )</h4>
+            <div class="answers">
+                <ng-container *ngFor="let answer of leader.answers" [ngSwitch]="answer">
+                    <div class="answers__answer answers__correct" *ngSwitchCase="true"></div>
+                    <div class="answers__answer answers__wrong" *ngSwitchCase="false"></div>
+                    <div class="answers__answer answers__missed" *ngSwitchDefault></div>
+                </ng-container>
+            </div>
         </div>
     </li>
 </ul>

--- a/hosting/src/app/games/quiz/leaderboard/leaderboard.component.scss
+++ b/hosting/src/app/games/quiz/leaderboard/leaderboard.component.scss
@@ -47,4 +47,33 @@
             }
         }
     }
+
+    .answers {
+        display: flex;
+        flex-direction: row;
+        counter-reset: answer;
+
+        &__answer:before {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin-right: 0.5em;
+            width: 2em;
+            height: 2em;
+            font-size: 0.8em;
+            border-radius: 50%;
+            border: 2px solid $brand-primary-dark;
+            counter-increment: answer;
+            content: counter(answer);
+        }
+
+        &__correct:before {
+            background-color: $brand-primary-dark;
+        }
+
+        &__wrong:before {
+            border-color: $brand-warning-dark;
+            background-color: $brand-warning-dark;
+        }
+    }
 }

--- a/hosting/src/app/games/quiz/quiz.model.ts
+++ b/hosting/src/app/games/quiz/quiz.model.ts
@@ -27,8 +27,9 @@ export interface QuestionSummary {
 }
 
 export interface RoundResult<T> {
-    user: T;
+    answers: Array<boolean>;
     score: number;
+    user: T;
 }
 
 export interface Round {


### PR DESCRIPTION
closes #44 

red = wrong
green = correct
transparent = missed

![Screenshot 2020-06-12 at 17 36 16](https://user-images.githubusercontent.com/773633/84525725-08dd8180-acd4-11ea-97ea-856176111035.png)
