### PR TITLE
Add firebase folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ Thumbs.db
 *.log
 
 # Firebase
-.firebase/*
+.firebase/

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 .DS_Store
 Thumbs.db
 *.log
+
+# Firebase
+.firebase/*


### PR DESCRIPTION
A very minor thing. This change adds the .firebase folder to the gitignore file as firebase places cache files in there for deployments. 